### PR TITLE
Search in correct documentation

### DIFF
--- a/src/ContentProvider/DevDocs.ts
+++ b/src/ContentProvider/DevDocs.ts
@@ -26,6 +26,7 @@ export interface Query {
     keyword?: string
     route?: '/' | '/settings' | '/offline'
     live?: boolean
+    search?: string
 }
 
 export function encodeDevDocsUri(query?: Query): Uri {
@@ -34,7 +35,18 @@ export function encodeDevDocsUri(query?: Query): Uri {
 
 export function decodeDevDocsUri(uri: Uri): Query {
     // TODO: runtime validation
-    return <Query>JSON.parse(uri.query)
+    const query = <Query>JSON.parse(uri.query)
+    const search = []
+    if (query.language) {
+        search.push(query.language)
+    }
+
+    if (query.keyword) {
+        search.push(query.keyword)
+    }
+
+    query.search = search.join(' ')
+    return query
 }
 
 const HTML_CONTENT = (query: Query) => `
@@ -54,7 +66,7 @@ iframe {
 </style>
 
 <body>
-    <iframe src="http://devdocs.io${query.route}#q=${query.keyword || ''}">
+    <iframe src="http://devdocs.io${query.route}#q=${query.search}">
     </iframe>
 </body>
 `

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -42,24 +42,36 @@ export function activate(context: vscode.ExtensionContext) {
         return value
     }
 
+    const getLanguageFromEditor = (editor = vscode.window.activeTextEditor): string => {
+        let value = ''
+
+        if (!!editor) {
+            value = editor.document.languageId
+        }
+
+        return value
+    }
+
     let homeCommand = vscode.commands.registerCommand('devdocs.home', () => {
         return openDevDocs()
     })
 
     let searchCommand = vscode.commands.registerTextEditorCommand('devdocs.search', (editor) => {
         let value = getKeywordFromEditor(editor)
+        const language = getLanguageFromEditor(editor)
         return vscode.window.showInputBox({
             prompt: 'Keyword',
             value
         })
-            .then((keyword) => openDevDocs({ keyword }, `DevDocs : Search${value !== '' ? ` - ${value}` : ''}`))
+            .then((keyword) => openDevDocs({ keyword, language }, `DevDocs : Search${value !== '' ? ` - ${value}` : ''}`))
     })
 
     let quickSearchCommand = vscode.commands.registerTextEditorCommand('devdocs.quickSearch', (editor) => {
         let keyword = getKeywordFromEditor(editor)
+        const language = getLanguageFromEditor(editor)
 
         return typeof keyword === 'string' && keyword !== ''
-            ? openDevDocs({ keyword }, `DevDocs : Search${keyword !== '' ? ` - ${keyword}` : ''}`)
+            ? openDevDocs({ keyword, language }, `DevDocs : Search${keyword !== '' ? ` - ${keyword}` : ''}`)
             : vscode.window.showInformationMessage('No search keywords found for DevDocs at current cursor position')
     })
 


### PR DESCRIPTION
## What is in this change?
Now includes the detected editor language as a prefix in the search.

## Before:
<img src="https://user-images.githubusercontent.com/6880880/31576821-82ab750c-b0c0-11e7-90d5-6775355e3e24.png" width="50%">

## After:
<img src="https://user-images.githubusercontent.com/6880880/31576818-741bafb6-b0c0-11e7-8008-29cc31442b0b.png" width="50%">

## References:
Closes #2 