### PR TITLE
Add support for configuring which column devdocs displays in

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,18 @@ The extension has no control over DevDocs. For best user experience, you should 
 
 For further information, please refer to [DevDocs Help](http://devdocs.io/help).
 
+## Extension Settings
+
+This extension contributes the following setting:
+
+```json
+"devdocs.column": {
+    "type": "number",
+    "default": 2,
+    "description": "A number which indicates which column (1, 2, or 3) to display DevDocs in"
+}
+```
+
 ## Known Issues
 
 * Document list in `devdocs.settings` page might be buggy (lose scroll position on first click)

--- a/package.json
+++ b/package.json
@@ -59,6 +59,8 @@
             "properties": {
                 "devdocs.column": {
                     "type": "number",
+                    "minimum": 1,
+                    "maximum": 3,
                     "default": 2,
                     "description": "A number which indicates which column (1, 2, or 3) to display DevDocs in"
                 }

--- a/package.json
+++ b/package.json
@@ -54,6 +54,16 @@
                 }
             ]
         },
+        "configuration": {
+            "title": "DevDocs: Configuration",
+            "properties": {
+                "devdocs.column": {
+                    "type": "number",
+                    "default": 2,
+                    "description": "A number which indicates which column (1, 2, or 3) to display DevDocs in"
+                }
+            }
+        },
         "keybindings": [
             {
                 "key": "alt+shift+d",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -12,8 +12,19 @@ export function activate(context: vscode.ExtensionContext) {
     let devdocs = new DevDocsContentProvider()
     let registration = vscode.workspace.registerTextDocumentContentProvider(SCHEME, devdocs)
 
+    const getColumn = () => {
+        const column = vscode.workspace.getConfiguration('devdocs').get('column');
+        switch (column) {
+            case 1: return vscode.ViewColumn.One;
+            case 2: return vscode.ViewColumn.Two;
+            case 3: return vscode.ViewColumn.Three;
+        }
+
+        return vscode.ViewColumn.Two;
+    }
+
     const openHtml = (uri: vscode.Uri, title) => {
-        return vscode.commands.executeCommand('vscode.previewHtml', uri, vscode.ViewColumn.Two, title)
+        return vscode.commands.executeCommand('vscode.previewHtml', uri, getColumn(), title)
             .then((success) => {
             }, (reason) => {
                 vscode.window.showErrorMessage(reason)

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,14 +13,10 @@ export function activate(context: vscode.ExtensionContext) {
     let registration = vscode.workspace.registerTextDocumentContentProvider(SCHEME, devdocs)
 
     const getColumn = () => {
-        const column = vscode.workspace.getConfiguration('devdocs').get('column');
-        switch (column) {
-            case 1: return vscode.ViewColumn.One;
-            case 2: return vscode.ViewColumn.Two;
-            case 3: return vscode.ViewColumn.Three;
-        }
-
-        return vscode.ViewColumn.Two;
+        const column = vscode.workspace.getConfiguration('devdocs').get<number>('column');
+        return column < 1 || column > 3
+            ? vscode.ViewColumn.Two
+            : <vscode.ViewColumn>column
     }
 
     const openHtml = (uri: vscode.Uri, title) => {


### PR DESCRIPTION
## What is in this change?
Now supports a configuration option for controlling which column devdocs displays in (defaults to current behavior of second column).

<img src="https://user-images.githubusercontent.com/6880880/31921403-786480e8-b82c-11e7-8c31-21a0cfae8bbe.png" width="500">

## References:
#3